### PR TITLE
Custom Button Styles

### DIFF
--- a/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.h
+++ b/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.h
@@ -25,6 +25,7 @@
 
 @property (nonatomic, assign) id<CustomIOSAlertViewDelegate> delegate;
 @property (nonatomic, retain) NSArray *buttonTitles;
+@property (nonatomic, retain) NSDictionary *buttonStyles;
 @property (nonatomic, assign) BOOL useMotionEffects;
 
 @property (copy) void (^onButtonTouchUpInside)(CustomIOSAlertView *alertView, int buttonIndex) ;

--- a/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.m
+++ b/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.m
@@ -25,6 +25,7 @@ CGFloat buttonSpacerHeight = 0;
 @synthesize parentView, containerView, dialogView, onButtonTouchUpInside;
 @synthesize delegate;
 @synthesize buttonTitles;
+@synthesize buttonStyles;
 @synthesize useMotionEffects;
 
 - (id)initWithParentView: (UIView *)_parentView
@@ -266,12 +267,37 @@ CGFloat buttonSpacerHeight = 0;
 
         [closeButton addTarget:self action:@selector(customIOS7dialogButtonTouchUpInside:) forControlEvents:UIControlEventTouchUpInside];
         [closeButton setTag:i];
-
+        
         [closeButton setTitle:[buttonTitles objectAtIndex:i] forState:UIControlStateNormal];
-        [closeButton setTitleColor:[UIColor colorWithRed:3.0f/255.0f green:122.0f/255.0f blue:1.0f alpha:1.0f] forState:UIControlStateNormal];
-        [closeButton setTitleColor:[UIColor colorWithRed:0.2f green:0.2f blue:0.2f alpha:0.5f] forState:UIControlStateHighlighted];
-        [closeButton.titleLabel setFont:[UIFont boldSystemFontOfSize:17.0f]];
         [closeButton.layer setCornerRadius:kCustomIOSAlertViewCornerRadius];
+        
+        UIColor *normalTitleColor;
+        UIColor *highlightedTitleColor;
+        UIFont *font;
+        
+        NSNumber *style = [buttonStyles objectForKey: [NSNumber numberWithInt: i]];
+        
+        switch ([style intValue]) {
+            case UIAlertActionStyleDefault:
+                normalTitleColor = [UIColor colorWithRed:3.0f/255.0f green:122.0f/255.0f blue:1.0f alpha:1.0f];
+                highlightedTitleColor = [UIColor colorWithRed:0.2f green:0.2f blue:0.2f alpha:0.5f];
+                font = [UIFont boldSystemFontOfSize:17.0f];
+                break;
+            case UIAlertActionStyleCancel:
+                normalTitleColor = [UIColor colorWithRed:3.0f/255.0f green:122.0f/255.0f blue:1.0f alpha:1.0f];
+                highlightedTitleColor = [UIColor colorWithRed:0.2f green:0.2f blue:0.2f alpha:0.5f];
+                font = [UIFont systemFontOfSize:17.0f];
+                break;
+            case UIAlertActionStyleDestructive:
+                normalTitleColor = [UIColor colorWithRed:255.0f/255.0f green:0.0f blue:0.0f alpha:1.0f];
+                highlightedTitleColor = [UIColor colorWithRed:0.2f green:0.2f blue:0.2f alpha:0.5f];
+                font = [UIFont systemFontOfSize:17.0f];
+                break;
+        }
+        
+        [closeButton setTitleColor:normalTitleColor forState:UIControlStateNormal];
+        [closeButton setTitleColor:highlightedTitleColor forState:UIControlStateHighlighted];
+        [closeButton.titleLabel setFont:font];
 
         [container addSubview:closeButton];
     }

--- a/CustomIOSAlertView/CustomIOSAlertView/ViewController.m
+++ b/CustomIOSAlertView/CustomIOSAlertView/ViewController.m
@@ -45,7 +45,12 @@
     [alertView setContainerView:[self createDemoView]];
 
     // Modify the parameters
-    [alertView setButtonTitles:[NSMutableArray arrayWithObjects:@"Close1", @"Close2", @"Close3", nil]];
+    [alertView setButtonTitles:[NSMutableArray arrayWithObjects:@"Default", @"Cancel", @"Destructive", nil]];
+    [alertView setButtonStyles: @{
+                                  [NSNumber numberWithInt: 0] : [NSNumber numberWithInt:UIAlertActionStyleDefault],
+                                  [NSNumber numberWithInt: 1] : [NSNumber numberWithInt:UIAlertActionStyleCancel],
+                                  [NSNumber numberWithInt: 2] : [NSNumber numberWithInt:UIAlertActionStyleDestructive],
+                                  }];
     [alertView setDelegate:self];
     
     // You may use a Block, rather than a delegate.


### PR DESCRIPTION
In order to keep it simple for now (and since we don't need more), I simply added the possibility of specifying an UIAlertActionStyle for each button, which is then used by the alert to render it with the same style as native iOS alerts.

If none is specified, the default value is used, which is the bold one.
